### PR TITLE
make list show pagination

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -23,7 +23,7 @@
     </li>
     {{ end }}
   </ul>
-  {{ if eq .Site.Params.showAllPostsArchive false }}
+  {{ if not .Site.Params.showAllPostsArchive}}
     {{ partial "pagination.html" . }}
   {{ end }}
 </div>


### PR DESCRIPTION
Thank you for your pretty themes.

It was comparing a string with bool showAllPostsArchive. So the page number is not shown in lists.

references [here](https://discourse.gohugo.io/t/how-to-test-for-true-false-values-in-front-matter/14034/2)